### PR TITLE
Add scope to the `Resource` trait

### DIFF
--- a/k8s-pb/src/api/admissionregistration/v1/mod.rs
+++ b/k8s-pb/src/api/admissionregistration/v1/mod.rs
@@ -572,7 +572,8 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "MutatingWebhookConfiguration";
-    const NAME: &'static str = "mutatingwebhookconfigurations";
+    const URL_PATH_SEGMENT: &'static str = "mutatingwebhookconfigurations";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for MutatingWebhookConfiguration {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -590,7 +591,8 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
-    const NAME: &'static str = "validatingwebhookconfigurations";
+    const URL_PATH_SEGMENT: &'static str = "validatingwebhookconfigurations";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ValidatingWebhookConfiguration {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/admissionregistration/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/admissionregistration/v1alpha1/mod.rs
@@ -634,7 +634,8 @@ impl crate::Resource for ValidatingAdmissionPolicy {
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const VERSION: &'static str = "v1alpha1";
     const KIND: &'static str = "ValidatingAdmissionPolicy";
-    const NAME: &'static str = "validatingadmissionpolicies";
+    const URL_PATH_SEGMENT: &'static str = "validatingadmissionpolicies";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ValidatingAdmissionPolicy {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -681,7 +682,8 @@ impl crate::Resource for ValidatingAdmissionPolicyBinding {
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const VERSION: &'static str = "v1alpha1";
     const KIND: &'static str = "ValidatingAdmissionPolicyBinding";
-    const NAME: &'static str = "validatingadmissionpolicybindings";
+    const URL_PATH_SEGMENT: &'static str = "validatingadmissionpolicybindings";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ValidatingAdmissionPolicyBinding {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/admissionregistration/v1beta1/mod.rs
+++ b/k8s-pb/src/api/admissionregistration/v1beta1/mod.rs
@@ -1125,7 +1125,8 @@ impl crate::Resource for ValidatingAdmissionPolicy {
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const VERSION: &'static str = "v1beta1";
     const KIND: &'static str = "ValidatingAdmissionPolicy";
-    const NAME: &'static str = "validatingadmissionpolicies";
+    const URL_PATH_SEGMENT: &'static str = "validatingadmissionpolicies";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ValidatingAdmissionPolicy {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -1172,7 +1173,8 @@ impl crate::Resource for ValidatingAdmissionPolicyBinding {
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const VERSION: &'static str = "v1beta1";
     const KIND: &'static str = "ValidatingAdmissionPolicyBinding";
-    const NAME: &'static str = "validatingadmissionpolicybindings";
+    const URL_PATH_SEGMENT: &'static str = "validatingadmissionpolicybindings";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ValidatingAdmissionPolicyBinding {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/apiserverinternal/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/apiserverinternal/v1alpha1/mod.rs
@@ -119,7 +119,8 @@ impl crate::Resource for StorageVersion {
     const GROUP: &'static str = "internal.apiserver.k8s.io";
     const VERSION: &'static str = "v1alpha1";
     const KIND: &'static str = "StorageVersion";
-    const NAME: &'static str = "storageversions";
+    const URL_PATH_SEGMENT: &'static str = "storageversions";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for StorageVersion {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/apps/v1/mod.rs
+++ b/k8s-pb/src/api/apps/v1/mod.rs
@@ -891,7 +891,8 @@ impl crate::Resource for ControllerRevision {
     const GROUP: &'static str = "apps";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "ControllerRevision";
-    const NAME: &'static str = "controllerrevisions";
+    const URL_PATH_SEGMENT: &'static str = "controllerrevisions";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for ControllerRevision {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -909,7 +910,8 @@ impl crate::Resource for DaemonSet {
     const GROUP: &'static str = "apps";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "DaemonSet";
-    const NAME: &'static str = "daemonsets";
+    const URL_PATH_SEGMENT: &'static str = "daemonsets";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for DaemonSet {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -956,7 +958,8 @@ impl crate::Resource for Deployment {
     const GROUP: &'static str = "apps";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Deployment";
-    const NAME: &'static str = "deployments";
+    const URL_PATH_SEGMENT: &'static str = "deployments";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Deployment {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -1003,7 +1006,8 @@ impl crate::Resource for ReplicaSet {
     const GROUP: &'static str = "apps";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "ReplicaSet";
-    const NAME: &'static str = "replicasets";
+    const URL_PATH_SEGMENT: &'static str = "replicasets";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for ReplicaSet {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -1050,7 +1054,8 @@ impl crate::Resource for StatefulSet {
     const GROUP: &'static str = "apps";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "StatefulSet";
-    const NAME: &'static str = "statefulsets";
+    const URL_PATH_SEGMENT: &'static str = "statefulsets";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for StatefulSet {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/authentication/v1/mod.rs
+++ b/k8s-pb/src/api/authentication/v1/mod.rs
@@ -212,7 +212,8 @@ impl crate::Resource for SelfSubjectReview {
     const GROUP: &'static str = "authentication.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "SelfSubjectReview";
-    const NAME: &'static str = "selfsubjectreviews";
+    const URL_PATH_SEGMENT: &'static str = "selfsubjectreviews";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for SelfSubjectReview {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -239,7 +240,8 @@ impl crate::Resource for TokenReview {
     const GROUP: &'static str = "authentication.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "TokenReview";
-    const NAME: &'static str = "tokenreviews";
+    const URL_PATH_SEGMENT: &'static str = "tokenreviews";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for TokenReview {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/authentication/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/authentication/v1alpha1/mod.rs
@@ -30,7 +30,8 @@ impl crate::Resource for SelfSubjectReview {
     const GROUP: &'static str = "authentication.k8s.io";
     const VERSION: &'static str = "v1alpha1";
     const KIND: &'static str = "SelfSubjectReview";
-    const NAME: &'static str = "selfsubjectreviews";
+    const URL_PATH_SEGMENT: &'static str = "selfsubjectreviews";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for SelfSubjectReview {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/authentication/v1beta1/mod.rs
+++ b/k8s-pb/src/api/authentication/v1beta1/mod.rs
@@ -132,7 +132,8 @@ impl crate::Resource for SelfSubjectReview {
     const GROUP: &'static str = "authentication.k8s.io";
     const VERSION: &'static str = "v1beta1";
     const KIND: &'static str = "SelfSubjectReview";
-    const NAME: &'static str = "selfsubjectreviews";
+    const URL_PATH_SEGMENT: &'static str = "selfsubjectreviews";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for SelfSubjectReview {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/authorization/v1/mod.rs
+++ b/k8s-pb/src/api/authorization/v1/mod.rs
@@ -291,7 +291,8 @@ impl crate::Resource for LocalSubjectAccessReview {
     const GROUP: &'static str = "authorization.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "LocalSubjectAccessReview";
-    const NAME: &'static str = "localsubjectaccessreviews";
+    const URL_PATH_SEGMENT: &'static str = "localsubjectaccessreviews";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for LocalSubjectAccessReview {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -327,7 +328,8 @@ impl crate::Resource for SelfSubjectAccessReview {
     const GROUP: &'static str = "authorization.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "SelfSubjectAccessReview";
-    const NAME: &'static str = "selfsubjectaccessreviews";
+    const URL_PATH_SEGMENT: &'static str = "selfsubjectaccessreviews";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for SelfSubjectAccessReview {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -363,7 +365,8 @@ impl crate::Resource for SelfSubjectRulesReview {
     const GROUP: &'static str = "authorization.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "SelfSubjectRulesReview";
-    const NAME: &'static str = "selfsubjectrulesreviews";
+    const URL_PATH_SEGMENT: &'static str = "selfsubjectrulesreviews";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for SelfSubjectRulesReview {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -399,7 +402,8 @@ impl crate::Resource for SubjectAccessReview {
     const GROUP: &'static str = "authorization.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "SubjectAccessReview";
-    const NAME: &'static str = "subjectaccessreviews";
+    const URL_PATH_SEGMENT: &'static str = "subjectaccessreviews";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for SubjectAccessReview {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/autoscaling/v1/mod.rs
+++ b/k8s-pb/src/api/autoscaling/v1/mod.rs
@@ -559,7 +559,8 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const GROUP: &'static str = "autoscaling";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "HorizontalPodAutoscaler";
-    const NAME: &'static str = "horizontalpodautoscalers";
+    const URL_PATH_SEGMENT: &'static str = "horizontalpodautoscalers";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for HorizontalPodAutoscaler {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/autoscaling/v2/mod.rs
+++ b/k8s-pb/src/api/autoscaling/v2/mod.rs
@@ -542,7 +542,8 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const GROUP: &'static str = "autoscaling";
     const VERSION: &'static str = "v2";
     const KIND: &'static str = "HorizontalPodAutoscaler";
-    const NAME: &'static str = "horizontalpodautoscalers";
+    const URL_PATH_SEGMENT: &'static str = "horizontalpodautoscalers";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for HorizontalPodAutoscaler {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/batch/v1/mod.rs
+++ b/k8s-pb/src/api/batch/v1/mod.rs
@@ -577,7 +577,8 @@ impl crate::Resource for CronJob {
     const GROUP: &'static str = "batch";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "CronJob";
-    const NAME: &'static str = "cronjobs";
+    const URL_PATH_SEGMENT: &'static str = "cronjobs";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for CronJob {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -613,7 +614,8 @@ impl crate::Resource for Job {
     const GROUP: &'static str = "batch";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Job";
-    const NAME: &'static str = "jobs";
+    const URL_PATH_SEGMENT: &'static str = "jobs";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Job {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/certificates/v1/mod.rs
+++ b/k8s-pb/src/api/certificates/v1/mod.rs
@@ -241,7 +241,8 @@ impl crate::Resource for CertificateSigningRequest {
     const GROUP: &'static str = "certificates.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "CertificateSigningRequest";
-    const NAME: &'static str = "certificatesigningrequests";
+    const URL_PATH_SEGMENT: &'static str = "certificatesigningrequests";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for CertificateSigningRequest {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/certificates/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/certificates/v1alpha1/mod.rs
@@ -87,7 +87,8 @@ impl crate::Resource for ClusterTrustBundle {
     const GROUP: &'static str = "certificates.k8s.io";
     const VERSION: &'static str = "v1alpha1";
     const KIND: &'static str = "ClusterTrustBundle";
-    const NAME: &'static str = "clustertrustbundles";
+    const URL_PATH_SEGMENT: &'static str = "clustertrustbundles";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ClusterTrustBundle {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/coordination/v1/mod.rs
+++ b/k8s-pb/src/api/coordination/v1/mod.rs
@@ -68,7 +68,8 @@ impl crate::Resource for Lease {
     const GROUP: &'static str = "coordination.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Lease";
-    const NAME: &'static str = "leases";
+    const URL_PATH_SEGMENT: &'static str = "leases";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Lease {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/core/v1/mod.rs
+++ b/k8s-pb/src/api/core/v1/mod.rs
@@ -7055,7 +7055,8 @@ impl crate::Resource for Binding {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Binding";
-    const NAME: &'static str = "bindings";
+    const URL_PATH_SEGMENT: &'static str = "bindings";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Binding {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7073,7 +7074,8 @@ impl crate::Resource for ComponentStatus {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "ComponentStatus";
-    const NAME: &'static str = "componentstatuses";
+    const URL_PATH_SEGMENT: &'static str = "componentstatuses";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ComponentStatus {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7091,7 +7093,8 @@ impl crate::Resource for ConfigMap {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "ConfigMap";
-    const NAME: &'static str = "configmaps";
+    const URL_PATH_SEGMENT: &'static str = "configmaps";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for ConfigMap {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7109,7 +7112,8 @@ impl crate::Resource for Endpoints {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Endpoints";
-    const NAME: &'static str = "endpoints";
+    const URL_PATH_SEGMENT: &'static str = "endpoints";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Endpoints {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7127,7 +7131,8 @@ impl crate::Resource for Event {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Event";
-    const NAME: &'static str = "events";
+    const URL_PATH_SEGMENT: &'static str = "events";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Event {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7145,7 +7150,8 @@ impl crate::Resource for LimitRange {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "LimitRange";
-    const NAME: &'static str = "limitranges";
+    const URL_PATH_SEGMENT: &'static str = "limitranges";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for LimitRange {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7172,7 +7178,8 @@ impl crate::Resource for Namespace {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Namespace";
-    const NAME: &'static str = "namespaces";
+    const URL_PATH_SEGMENT: &'static str = "namespaces";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for Namespace {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7219,7 +7226,8 @@ impl crate::Resource for Node {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Node";
-    const NAME: &'static str = "nodes";
+    const URL_PATH_SEGMENT: &'static str = "nodes";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for Node {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7266,7 +7274,8 @@ impl crate::Resource for PersistentVolume {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "PersistentVolume";
-    const NAME: &'static str = "persistentvolumes";
+    const URL_PATH_SEGMENT: &'static str = "persistentvolumes";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for PersistentVolume {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7302,7 +7311,8 @@ impl crate::Resource for PersistentVolumeClaim {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "PersistentVolumeClaim";
-    const NAME: &'static str = "persistentvolumeclaims";
+    const URL_PATH_SEGMENT: &'static str = "persistentvolumeclaims";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for PersistentVolumeClaim {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7349,7 +7359,8 @@ impl crate::Resource for Pod {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Pod";
-    const NAME: &'static str = "pods";
+    const URL_PATH_SEGMENT: &'static str = "pods";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Pod {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7396,7 +7407,8 @@ impl crate::Resource for PodTemplate {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "PodTemplate";
-    const NAME: &'static str = "podtemplates";
+    const URL_PATH_SEGMENT: &'static str = "podtemplates";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for PodTemplate {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7414,7 +7426,8 @@ impl crate::Resource for ReplicationController {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "ReplicationController";
-    const NAME: &'static str = "replicationcontrollers";
+    const URL_PATH_SEGMENT: &'static str = "replicationcontrollers";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for ReplicationController {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7461,7 +7474,8 @@ impl crate::Resource for ResourceQuota {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "ResourceQuota";
-    const NAME: &'static str = "resourcequotas";
+    const URL_PATH_SEGMENT: &'static str = "resourcequotas";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for ResourceQuota {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7497,7 +7511,8 @@ impl crate::Resource for Secret {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Secret";
-    const NAME: &'static str = "secrets";
+    const URL_PATH_SEGMENT: &'static str = "secrets";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Secret {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7515,7 +7530,8 @@ impl crate::Resource for Service {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Service";
-    const NAME: &'static str = "services";
+    const URL_PATH_SEGMENT: &'static str = "services";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Service {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -7562,7 +7578,8 @@ impl crate::Resource for ServiceAccount {
     const GROUP: &'static str = "";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "ServiceAccount";
-    const NAME: &'static str = "serviceaccounts";
+    const URL_PATH_SEGMENT: &'static str = "serviceaccounts";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for ServiceAccount {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/discovery/v1/mod.rs
+++ b/k8s-pb/src/api/discovery/v1/mod.rs
@@ -199,7 +199,8 @@ impl crate::Resource for EndpointSlice {
     const GROUP: &'static str = "discovery.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "EndpointSlice";
-    const NAME: &'static str = "endpointslices";
+    const URL_PATH_SEGMENT: &'static str = "endpointslices";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for EndpointSlice {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/events/v1/mod.rs
+++ b/k8s-pb/src/api/events/v1/mod.rs
@@ -119,7 +119,8 @@ impl crate::Resource for Event {
     const GROUP: &'static str = "events.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Event";
-    const NAME: &'static str = "events";
+    const URL_PATH_SEGMENT: &'static str = "events";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Event {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/flowcontrol/v1/mod.rs
+++ b/k8s-pb/src/api/flowcontrol/v1/mod.rs
@@ -554,7 +554,8 @@ impl crate::Resource for FlowSchema {
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "FlowSchema";
-    const NAME: &'static str = "flowschemas";
+    const URL_PATH_SEGMENT: &'static str = "flowschemas";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for FlowSchema {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -601,7 +602,8 @@ impl crate::Resource for PriorityLevelConfiguration {
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "PriorityLevelConfiguration";
-    const NAME: &'static str = "prioritylevelconfigurations";
+    const URL_PATH_SEGMENT: &'static str = "prioritylevelconfigurations";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for PriorityLevelConfiguration {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/flowcontrol/v1beta3/mod.rs
+++ b/k8s-pb/src/api/flowcontrol/v1beta3/mod.rs
@@ -549,7 +549,8 @@ impl crate::Resource for FlowSchema {
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const VERSION: &'static str = "v1beta3";
     const KIND: &'static str = "FlowSchema";
-    const NAME: &'static str = "flowschemas";
+    const URL_PATH_SEGMENT: &'static str = "flowschemas";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for FlowSchema {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -596,7 +597,8 @@ impl crate::Resource for PriorityLevelConfiguration {
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const VERSION: &'static str = "v1beta3";
     const KIND: &'static str = "PriorityLevelConfiguration";
-    const NAME: &'static str = "prioritylevelconfigurations";
+    const URL_PATH_SEGMENT: &'static str = "prioritylevelconfigurations";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for PriorityLevelConfiguration {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/networking/v1/mod.rs
+++ b/k8s-pb/src/api/networking/v1/mod.rs
@@ -594,7 +594,8 @@ impl crate::Resource for Ingress {
     const GROUP: &'static str = "networking.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Ingress";
-    const NAME: &'static str = "ingresses";
+    const URL_PATH_SEGMENT: &'static str = "ingresses";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Ingress {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -630,7 +631,8 @@ impl crate::Resource for IngressClass {
     const GROUP: &'static str = "networking.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "IngressClass";
-    const NAME: &'static str = "ingressclasses";
+    const URL_PATH_SEGMENT: &'static str = "ingressclasses";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for IngressClass {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -657,7 +659,8 @@ impl crate::Resource for NetworkPolicy {
     const GROUP: &'static str = "networking.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "NetworkPolicy";
-    const NAME: &'static str = "networkpolicies";
+    const URL_PATH_SEGMENT: &'static str = "networkpolicies";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for NetworkPolicy {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/networking/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/networking/v1alpha1/mod.rs
@@ -138,7 +138,8 @@ impl crate::Resource for IpAddress {
     const GROUP: &'static str = "networking.k8s.io";
     const VERSION: &'static str = "v1alpha1";
     const KIND: &'static str = "IPAddress";
-    const NAME: &'static str = "ipaddresses";
+    const URL_PATH_SEGMENT: &'static str = "ipaddresses";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for IpAddress {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -165,7 +166,8 @@ impl crate::Resource for ServiceCidr {
     const GROUP: &'static str = "networking.k8s.io";
     const VERSION: &'static str = "v1alpha1";
     const KIND: &'static str = "ServiceCIDR";
-    const NAME: &'static str = "servicecidrs";
+    const URL_PATH_SEGMENT: &'static str = "servicecidrs";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ServiceCidr {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/node/v1/mod.rs
+++ b/k8s-pb/src/api/node/v1/mod.rs
@@ -98,7 +98,8 @@ impl crate::Resource for RuntimeClass {
     const GROUP: &'static str = "node.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "RuntimeClass";
-    const NAME: &'static str = "runtimeclasses";
+    const URL_PATH_SEGMENT: &'static str = "runtimeclasses";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for RuntimeClass {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/policy/v1/mod.rs
+++ b/k8s-pb/src/api/policy/v1/mod.rs
@@ -183,7 +183,8 @@ impl crate::Resource for PodDisruptionBudget {
     const GROUP: &'static str = "policy";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "PodDisruptionBudget";
-    const NAME: &'static str = "poddisruptionbudgets";
+    const URL_PATH_SEGMENT: &'static str = "poddisruptionbudgets";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for PodDisruptionBudget {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/rbac/v1/mod.rs
+++ b/k8s-pb/src/api/rbac/v1/mod.rs
@@ -219,7 +219,8 @@ impl crate::Resource for ClusterRole {
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "ClusterRole";
-    const NAME: &'static str = "clusterroles";
+    const URL_PATH_SEGMENT: &'static str = "clusterroles";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ClusterRole {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -237,7 +238,8 @@ impl crate::Resource for ClusterRoleBinding {
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "ClusterRoleBinding";
-    const NAME: &'static str = "clusterrolebindings";
+    const URL_PATH_SEGMENT: &'static str = "clusterrolebindings";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ClusterRoleBinding {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -255,7 +257,8 @@ impl crate::Resource for Role {
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "Role";
-    const NAME: &'static str = "roles";
+    const URL_PATH_SEGMENT: &'static str = "roles";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for Role {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -273,7 +276,8 @@ impl crate::Resource for RoleBinding {
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "RoleBinding";
-    const NAME: &'static str = "rolebindings";
+    const URL_PATH_SEGMENT: &'static str = "rolebindings";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for RoleBinding {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/resource/v1alpha2/mod.rs
+++ b/k8s-pb/src/api/resource/v1alpha2/mod.rs
@@ -429,7 +429,8 @@ impl crate::Resource for PodSchedulingContext {
     const GROUP: &'static str = "resource.k8s.io";
     const VERSION: &'static str = "v1alpha2";
     const KIND: &'static str = "PodSchedulingContext";
-    const NAME: &'static str = "podschedulingcontexts";
+    const URL_PATH_SEGMENT: &'static str = "podschedulingcontexts";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for PodSchedulingContext {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -465,7 +466,8 @@ impl crate::Resource for ResourceClaim {
     const GROUP: &'static str = "resource.k8s.io";
     const VERSION: &'static str = "v1alpha2";
     const KIND: &'static str = "ResourceClaim";
-    const NAME: &'static str = "resourceclaims";
+    const URL_PATH_SEGMENT: &'static str = "resourceclaims";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for ResourceClaim {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -501,7 +503,8 @@ impl crate::Resource for ResourceClaimTemplate {
     const GROUP: &'static str = "resource.k8s.io";
     const VERSION: &'static str = "v1alpha2";
     const KIND: &'static str = "ResourceClaimTemplate";
-    const NAME: &'static str = "resourceclaimtemplates";
+    const URL_PATH_SEGMENT: &'static str = "resourceclaimtemplates";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for ResourceClaimTemplate {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -528,7 +531,8 @@ impl crate::Resource for ResourceClass {
     const GROUP: &'static str = "resource.k8s.io";
     const VERSION: &'static str = "v1alpha2";
     const KIND: &'static str = "ResourceClass";
-    const NAME: &'static str = "resourceclasses";
+    const URL_PATH_SEGMENT: &'static str = "resourceclasses";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ResourceClass {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/scheduling/v1/mod.rs
+++ b/k8s-pb/src/api/scheduling/v1/mod.rs
@@ -55,7 +55,8 @@ impl crate::Resource for PriorityClass {
     const GROUP: &'static str = "scheduling.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "PriorityClass";
-    const NAME: &'static str = "priorityclasses";
+    const URL_PATH_SEGMENT: &'static str = "priorityclasses";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for PriorityClass {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/storage/v1/mod.rs
+++ b/k8s-pb/src/api/storage/v1/mod.rs
@@ -621,7 +621,8 @@ impl crate::Resource for CsiDriver {
     const GROUP: &'static str = "storage.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "CSIDriver";
-    const NAME: &'static str = "csidrivers";
+    const URL_PATH_SEGMENT: &'static str = "csidrivers";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for CsiDriver {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -648,7 +649,8 @@ impl crate::Resource for CsiNode {
     const GROUP: &'static str = "storage.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "CSINode";
-    const NAME: &'static str = "csinodes";
+    const URL_PATH_SEGMENT: &'static str = "csinodes";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for CsiNode {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -675,7 +677,8 @@ impl crate::Resource for CsiStorageCapacity {
     const GROUP: &'static str = "storage.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "CSIStorageCapacity";
-    const NAME: &'static str = "csistoragecapacities";
+    const URL_PATH_SEGMENT: &'static str = "csistoragecapacities";
+    type Scope = crate::NamespaceResourceScope;
 }
 impl crate::HasMetadata for CsiStorageCapacity {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -693,7 +696,8 @@ impl crate::Resource for StorageClass {
     const GROUP: &'static str = "storage.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "StorageClass";
-    const NAME: &'static str = "storageclasses";
+    const URL_PATH_SEGMENT: &'static str = "storageclasses";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for StorageClass {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -711,7 +715,8 @@ impl crate::Resource for VolumeAttachment {
     const GROUP: &'static str = "storage.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "VolumeAttachment";
-    const NAME: &'static str = "volumeattachments";
+    const URL_PATH_SEGMENT: &'static str = "volumeattachments";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for VolumeAttachment {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/api/storage/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/storage/v1alpha1/mod.rs
@@ -291,7 +291,8 @@ impl crate::Resource for VolumeAttributesClass {
     const GROUP: &'static str = "storage.k8s.io";
     const VERSION: &'static str = "v1alpha1";
     const KIND: &'static str = "VolumeAttributesClass";
-    const NAME: &'static str = "volumeattributesclasses";
+    const URL_PATH_SEGMENT: &'static str = "volumeattributesclasses";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for VolumeAttributesClass {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/apiextensions_apiserver/pkg/apis/apiextensions/v1/mod.rs
+++ b/k8s-pb/src/apiextensions_apiserver/pkg/apis/apiextensions/v1/mod.rs
@@ -852,7 +852,8 @@ impl crate::Resource for CustomResourceDefinition {
     const GROUP: &'static str = "apiextensions.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "CustomResourceDefinition";
-    const NAME: &'static str = "customresourcedefinitions";
+    const URL_PATH_SEGMENT: &'static str = "customresourcedefinitions";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for CustomResourceDefinition {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/kube_aggregator/pkg/apis/apiregistration/v1/mod.rs
+++ b/k8s-pb/src/kube_aggregator/pkg/apis/apiregistration/v1/mod.rs
@@ -143,7 +143,8 @@ impl crate::Resource for ApiService {
     const GROUP: &'static str = "apiregistration.k8s.io";
     const VERSION: &'static str = "v1";
     const KIND: &'static str = "APIService";
-    const NAME: &'static str = "apiservices";
+    const URL_PATH_SEGMENT: &'static str = "apiservices";
+    type Scope = crate::ClusterResourceScope;
 }
 impl crate::HasMetadata for ApiService {
     type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/k8s-pb/src/lib.rs
+++ b/k8s-pb/src/lib.rs
@@ -4,12 +4,46 @@ pub mod apimachinery;
 pub mod kube_aggregator;
 pub mod metrics;
 
+#[doc = r" The scope of a [`Resource`]."]
+pub trait ResourceScope {}
+#[doc = r" Indicates that a [`Resource`] is cluster-scoped."]
+pub struct ClusterResourceScope {}
+impl ResourceScope for ClusterResourceScope {}
+#[doc = r" Indicates that a [`Resource`] is namespace-scoped."]
+pub struct NamespaceResourceScope {}
+impl ResourceScope for NamespaceResourceScope {}
+#[doc = r" Indicates that a [`Resource`] is neither cluster-scoped nor namespace-scoped."]
+pub struct SubResourceScope {}
+impl ResourceScope for SubResourceScope {}
+#[doc = r" A trait applied to all Kubernetes resources."]
 pub trait Resource {
+    #[doc = r#" The API version of the resource. This is a composite of [`Resource::GROUP`] and [`Resource::VERSION`] (eg `"apiextensions.k8s.io/v1beta1"`)"#]
+    #[doc = r#" or just the version for resources without a group (eg `"v1"`)."#]
+    #[doc = r""]
+    #[doc = r" This is the string used in the `apiVersion` field of the resource's serialized form."]
     const API_VERSION: &'static str;
+    #[doc = r" The group of the resource, or the empty string if the resource doesn't have a group."]
     const GROUP: &'static str;
-    const VERSION: &'static str;
+    #[doc = r" The kind of the resource."]
+    #[doc = r""]
+    #[doc = r" This is the string used in the `kind` field of the resource's serialized form."]
     const KIND: &'static str;
-    const NAME: &'static str;
+    #[doc = r" The version of the resource."]
+    const VERSION: &'static str;
+    #[doc = r" The URL path segment used to construct URLs related to this resource."]
+    #[doc = r""]
+    #[doc = r" For cluster- and namespaced-scoped resources, this is the plural name of the resource that is followed by the resource name."]
+    #[doc = r#" For example, [`api::core::v1::Pod`](crate::api::core::v1::Pod)'s value is `"pods"` and its URLs look like `.../pods/{name}`."#]
+    #[doc = r""]
+    #[doc = r" For subresources, this is the subresource name that comes after the parent resource's name."]
+    #[doc = r#" For example, [`api::authentication::v1::TokenRequest`](crate::api::authentication::v1::TokenRequest)'s value is `"token"`,"#]
+    #[doc = r" and its URLs look like `.../serviceaccounts/{name}/token`."]
+    const URL_PATH_SEGMENT: &'static str;
+    #[doc = r" Indicates whether the resource is namespace-scoped or cluster-scoped or a subresource."]
+    #[doc = r""]
+    #[doc = r" If you need to restrict some generic code to resources of a specific scope, use this associated type to create a bound on the generic."]
+    #[doc = r" For example, `fn foo<T: k8s_openapi::Resource<Scope = k8s_openapi::ClusterResourceScope>>() { }` can only be called with cluster-scoped resources."]
+    type Scope: ResourceScope;
 }
 pub trait HasMetadata {
     type Metadata;


### PR DESCRIPTION
For #4

Note because of https://github.com/kube-rs/k8s-pb/issues/26 we only actually need to implement 2 scopes; cluster + namespaced as the subresource scopes are not yet captured.