### PR TITLE
Revert "Update prost-types requirement from 0.12.3 to 0.13.1"

### DIFF
--- a/k8s-pb-codegen/Cargo.toml
+++ b/k8s-pb-codegen/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 prost = "0.13.1"
 prost-build = "0.13.1"
-prost-types = "0.13.1"
+prost-types = "0.12.3"
 serde_json = "1.0.67"
 serde = { version = "1.0.130", features = ["derive"] }
 log = "0.4.14"


### PR DESCRIPTION
Reverts kube-rs/k8s-pb#39
breakss codegen