### PR TITLE
Rename HasMetadata -> Metadata to align with k8s-openapi

### DIFF
--- a/k8s-pb-codegen/src/main.rs
+++ b/k8s-pb-codegen/src/main.rs
@@ -170,10 +170,11 @@ fn append_trait_def(lib_rs: &mut File) {
             type Scope: ResourceScope;
         }
 
-        pub trait HasMetadata {
-            type Metadata;
-            fn metadata(&self) -> Option<&Self::Metadata>;
-            fn metadata_mut(&mut self) -> Option<&mut Self::Metadata>;
+        /// A trait applied to all Kubernetes resources that have Metadata
+        pub trait Metadata: Resource {
+            type Ty;
+            fn metadata(&self) -> Option<&Self::Ty>;
+            fn metadata_mut(&mut self) -> Option<&mut Self::Ty>;
         }
         pub trait HasSpec {
             type Spec;
@@ -226,13 +227,13 @@ fn append_trait_impl(pkg_rs: &mut File, message_name: &str, resource: &Resource)
         quote! {
             #tokens
 
-            impl crate::HasMetadata for #type_name {
-                type Metadata = crate::#(#metadata)::*;
+            impl crate::Metadata for #type_name {
+                type Ty = crate::#(#metadata)::*;
 
-                fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+                fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
                     self.metadata.as_ref()
                 }
-                fn metadata_mut(&mut self) -> Option<&mut<Self as crate::HasMetadata>::Metadata> {
+                fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
                     self.metadata.as_mut()
                 }
             }

--- a/k8s-pb/src/api/admissionregistration/v1/mod.rs
+++ b/k8s-pb/src/api/admissionregistration/v1/mod.rs
@@ -1124,12 +1124,12 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const URL_PATH_SEGMENT: &'static str = "mutatingwebhookconfigurations";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for MutatingWebhookConfiguration {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for MutatingWebhookConfiguration {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -1142,12 +1142,12 @@ impl crate::Resource for ValidatingAdmissionPolicy {
     const URL_PATH_SEGMENT: &'static str = "validatingadmissionpolicies";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ValidatingAdmissionPolicy {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ValidatingAdmissionPolicy {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -1187,12 +1187,12 @@ impl crate::Resource for ValidatingAdmissionPolicyBinding {
     const URL_PATH_SEGMENT: &'static str = "validatingadmissionpolicybindings";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ValidatingAdmissionPolicyBinding {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ValidatingAdmissionPolicyBinding {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -1214,12 +1214,12 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const URL_PATH_SEGMENT: &'static str = "validatingwebhookconfigurations";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ValidatingWebhookConfiguration {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ValidatingWebhookConfiguration {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/admissionregistration/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/admissionregistration/v1alpha1/mod.rs
@@ -607,12 +607,12 @@ impl crate::Resource for ValidatingAdmissionPolicy {
     const URL_PATH_SEGMENT: &'static str = "validatingadmissionpolicies";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ValidatingAdmissionPolicy {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ValidatingAdmissionPolicy {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -652,12 +652,12 @@ impl crate::Resource for ValidatingAdmissionPolicyBinding {
     const URL_PATH_SEGMENT: &'static str = "validatingadmissionpolicybindings";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ValidatingAdmissionPolicyBinding {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ValidatingAdmissionPolicyBinding {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/admissionregistration/v1beta1/mod.rs
+++ b/k8s-pb/src/api/admissionregistration/v1beta1/mod.rs
@@ -1077,12 +1077,12 @@ impl crate::Resource for ValidatingAdmissionPolicy {
     const URL_PATH_SEGMENT: &'static str = "validatingadmissionpolicies";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ValidatingAdmissionPolicy {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ValidatingAdmissionPolicy {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -1122,12 +1122,12 @@ impl crate::Resource for ValidatingAdmissionPolicyBinding {
     const URL_PATH_SEGMENT: &'static str = "validatingadmissionpolicybindings";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ValidatingAdmissionPolicyBinding {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ValidatingAdmissionPolicyBinding {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/apiserverinternal/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/apiserverinternal/v1alpha1/mod.rs
@@ -111,12 +111,12 @@ impl crate::Resource for StorageVersion {
     const URL_PATH_SEGMENT: &'static str = "storageversions";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for StorageVersion {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for StorageVersion {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/apps/v1/mod.rs
+++ b/k8s-pb/src/api/apps/v1/mod.rs
@@ -832,12 +832,12 @@ impl crate::Resource for ControllerRevision {
     const URL_PATH_SEGMENT: &'static str = "controllerrevisions";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for ControllerRevision {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ControllerRevision {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -850,12 +850,12 @@ impl crate::Resource for DaemonSet {
     const URL_PATH_SEGMENT: &'static str = "daemonsets";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for DaemonSet {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for DaemonSet {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -895,12 +895,12 @@ impl crate::Resource for Deployment {
     const URL_PATH_SEGMENT: &'static str = "deployments";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Deployment {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Deployment {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -940,12 +940,12 @@ impl crate::Resource for ReplicaSet {
     const URL_PATH_SEGMENT: &'static str = "replicasets";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for ReplicaSet {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ReplicaSet {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -985,12 +985,12 @@ impl crate::Resource for StatefulSet {
     const URL_PATH_SEGMENT: &'static str = "statefulsets";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for StatefulSet {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for StatefulSet {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/authentication/v1/mod.rs
+++ b/k8s-pb/src/api/authentication/v1/mod.rs
@@ -202,12 +202,12 @@ impl crate::Resource for SelfSubjectReview {
     const URL_PATH_SEGMENT: &'static str = "selfsubjectreviews";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for SelfSubjectReview {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for SelfSubjectReview {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -229,12 +229,12 @@ impl crate::Resource for TokenReview {
     const URL_PATH_SEGMENT: &'static str = "tokenreviews";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for TokenReview {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for TokenReview {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/authentication/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/authentication/v1alpha1/mod.rs
@@ -30,12 +30,12 @@ impl crate::Resource for SelfSubjectReview {
     const URL_PATH_SEGMENT: &'static str = "selfsubjectreviews";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for SelfSubjectReview {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for SelfSubjectReview {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/authentication/v1beta1/mod.rs
+++ b/k8s-pb/src/api/authentication/v1beta1/mod.rs
@@ -128,12 +128,12 @@ impl crate::Resource for SelfSubjectReview {
     const URL_PATH_SEGMENT: &'static str = "selfsubjectreviews";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for SelfSubjectReview {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for SelfSubjectReview {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/authorization/v1/mod.rs
+++ b/k8s-pb/src/api/authorization/v1/mod.rs
@@ -356,12 +356,12 @@ impl crate::Resource for LocalSubjectAccessReview {
     const URL_PATH_SEGMENT: &'static str = "localsubjectaccessreviews";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for LocalSubjectAccessReview {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for LocalSubjectAccessReview {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -392,12 +392,12 @@ impl crate::Resource for SelfSubjectAccessReview {
     const URL_PATH_SEGMENT: &'static str = "selfsubjectaccessreviews";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for SelfSubjectAccessReview {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for SelfSubjectAccessReview {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -428,12 +428,12 @@ impl crate::Resource for SelfSubjectRulesReview {
     const URL_PATH_SEGMENT: &'static str = "selfsubjectrulesreviews";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for SelfSubjectRulesReview {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for SelfSubjectRulesReview {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -464,12 +464,12 @@ impl crate::Resource for SubjectAccessReview {
     const URL_PATH_SEGMENT: &'static str = "subjectaccessreviews";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for SubjectAccessReview {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for SubjectAccessReview {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/autoscaling/v1/mod.rs
+++ b/k8s-pb/src/api/autoscaling/v1/mod.rs
@@ -511,12 +511,12 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const URL_PATH_SEGMENT: &'static str = "horizontalpodautoscalers";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for HorizontalPodAutoscaler {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for HorizontalPodAutoscaler {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/autoscaling/v2/mod.rs
+++ b/k8s-pb/src/api/autoscaling/v2/mod.rs
@@ -508,12 +508,12 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const URL_PATH_SEGMENT: &'static str = "horizontalpodautoscalers";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for HorizontalPodAutoscaler {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for HorizontalPodAutoscaler {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/batch/v1/mod.rs
+++ b/k8s-pb/src/api/batch/v1/mod.rs
@@ -635,12 +635,12 @@ impl crate::Resource for CronJob {
     const URL_PATH_SEGMENT: &'static str = "cronjobs";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for CronJob {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for CronJob {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -671,12 +671,12 @@ impl crate::Resource for Job {
     const URL_PATH_SEGMENT: &'static str = "jobs";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Job {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Job {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/certificates/v1/mod.rs
+++ b/k8s-pb/src/api/certificates/v1/mod.rs
@@ -233,12 +233,12 @@ impl crate::Resource for CertificateSigningRequest {
     const URL_PATH_SEGMENT: &'static str = "certificatesigningrequests";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for CertificateSigningRequest {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for CertificateSigningRequest {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/certificates/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/certificates/v1alpha1/mod.rs
@@ -84,12 +84,12 @@ impl crate::Resource for ClusterTrustBundle {
     const URL_PATH_SEGMENT: &'static str = "clustertrustbundles";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ClusterTrustBundle {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ClusterTrustBundle {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/coordination/v1/mod.rs
+++ b/k8s-pb/src/api/coordination/v1/mod.rs
@@ -78,12 +78,12 @@ impl crate::Resource for Lease {
     const URL_PATH_SEGMENT: &'static str = "leases";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Lease {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Lease {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/coordination/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/coordination/v1alpha1/mod.rs
@@ -85,12 +85,12 @@ impl crate::Resource for LeaseCandidate {
     const URL_PATH_SEGMENT: &'static str = "leasecandidates";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for LeaseCandidate {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for LeaseCandidate {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/core/v1/mod.rs
+++ b/k8s-pb/src/api/core/v1/mod.rs
@@ -7049,12 +7049,12 @@ impl crate::Resource for Binding {
     const URL_PATH_SEGMENT: &'static str = "bindings";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Binding {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Binding {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7067,12 +7067,12 @@ impl crate::Resource for ComponentStatus {
     const URL_PATH_SEGMENT: &'static str = "componentstatuses";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ComponentStatus {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ComponentStatus {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7085,12 +7085,12 @@ impl crate::Resource for ConfigMap {
     const URL_PATH_SEGMENT: &'static str = "configmaps";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for ConfigMap {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ConfigMap {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7103,12 +7103,12 @@ impl crate::Resource for Endpoints {
     const URL_PATH_SEGMENT: &'static str = "endpoints";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Endpoints {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Endpoints {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7121,12 +7121,12 @@ impl crate::Resource for Event {
     const URL_PATH_SEGMENT: &'static str = "events";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Event {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Event {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7139,12 +7139,12 @@ impl crate::Resource for LimitRange {
     const URL_PATH_SEGMENT: &'static str = "limitranges";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for LimitRange {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for LimitRange {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7166,12 +7166,12 @@ impl crate::Resource for Namespace {
     const URL_PATH_SEGMENT: &'static str = "namespaces";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for Namespace {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Namespace {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7211,12 +7211,12 @@ impl crate::Resource for Node {
     const URL_PATH_SEGMENT: &'static str = "nodes";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for Node {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Node {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7256,12 +7256,12 @@ impl crate::Resource for PersistentVolume {
     const URL_PATH_SEGMENT: &'static str = "persistentvolumes";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for PersistentVolume {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for PersistentVolume {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7292,12 +7292,12 @@ impl crate::Resource for PersistentVolumeClaim {
     const URL_PATH_SEGMENT: &'static str = "persistentvolumeclaims";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for PersistentVolumeClaim {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for PersistentVolumeClaim {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7337,12 +7337,12 @@ impl crate::Resource for Pod {
     const URL_PATH_SEGMENT: &'static str = "pods";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Pod {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Pod {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7382,12 +7382,12 @@ impl crate::Resource for PodTemplate {
     const URL_PATH_SEGMENT: &'static str = "podtemplates";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for PodTemplate {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for PodTemplate {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7400,12 +7400,12 @@ impl crate::Resource for ReplicationController {
     const URL_PATH_SEGMENT: &'static str = "replicationcontrollers";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for ReplicationController {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ReplicationController {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7445,12 +7445,12 @@ impl crate::Resource for ResourceQuota {
     const URL_PATH_SEGMENT: &'static str = "resourcequotas";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for ResourceQuota {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ResourceQuota {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7481,12 +7481,12 @@ impl crate::Resource for Secret {
     const URL_PATH_SEGMENT: &'static str = "secrets";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Secret {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Secret {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7499,12 +7499,12 @@ impl crate::Resource for Service {
     const URL_PATH_SEGMENT: &'static str = "services";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Service {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Service {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -7544,12 +7544,12 @@ impl crate::Resource for ServiceAccount {
     const URL_PATH_SEGMENT: &'static str = "serviceaccounts";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for ServiceAccount {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ServiceAccount {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/discovery/v1/mod.rs
+++ b/k8s-pb/src/api/discovery/v1/mod.rs
@@ -190,12 +190,12 @@ impl crate::Resource for EndpointSlice {
     const URL_PATH_SEGMENT: &'static str = "endpointslices";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for EndpointSlice {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for EndpointSlice {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/events/v1/mod.rs
+++ b/k8s-pb/src/api/events/v1/mod.rs
@@ -111,12 +111,12 @@ impl crate::Resource for Event {
     const URL_PATH_SEGMENT: &'static str = "events";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Event {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Event {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/flowcontrol/v1/mod.rs
+++ b/k8s-pb/src/api/flowcontrol/v1/mod.rs
@@ -523,12 +523,12 @@ impl crate::Resource for FlowSchema {
     const URL_PATH_SEGMENT: &'static str = "flowschemas";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for FlowSchema {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for FlowSchema {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -568,12 +568,12 @@ impl crate::Resource for PriorityLevelConfiguration {
     const URL_PATH_SEGMENT: &'static str = "prioritylevelconfigurations";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for PriorityLevelConfiguration {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for PriorityLevelConfiguration {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/flowcontrol/v1beta3/mod.rs
+++ b/k8s-pb/src/api/flowcontrol/v1beta3/mod.rs
@@ -518,12 +518,12 @@ impl crate::Resource for FlowSchema {
     const URL_PATH_SEGMENT: &'static str = "flowschemas";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for FlowSchema {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for FlowSchema {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -563,12 +563,12 @@ impl crate::Resource for PriorityLevelConfiguration {
     const URL_PATH_SEGMENT: &'static str = "prioritylevelconfigurations";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for PriorityLevelConfiguration {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for PriorityLevelConfiguration {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/networking/v1/mod.rs
+++ b/k8s-pb/src/api/networking/v1/mod.rs
@@ -562,12 +562,12 @@ impl crate::Resource for Ingress {
     const URL_PATH_SEGMENT: &'static str = "ingresses";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Ingress {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Ingress {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -598,12 +598,12 @@ impl crate::Resource for IngressClass {
     const URL_PATH_SEGMENT: &'static str = "ingressclasses";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for IngressClass {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for IngressClass {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -625,12 +625,12 @@ impl crate::Resource for NetworkPolicy {
     const URL_PATH_SEGMENT: &'static str = "networkpolicies";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for NetworkPolicy {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for NetworkPolicy {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/networking/v1beta1/mod.rs
+++ b/k8s-pb/src/api/networking/v1beta1/mod.rs
@@ -465,12 +465,12 @@ impl crate::Resource for IpAddress {
     const URL_PATH_SEGMENT: &'static str = "ipaddresses";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for IpAddress {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for IpAddress {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -492,12 +492,12 @@ impl crate::Resource for ServiceCidr {
     const URL_PATH_SEGMENT: &'static str = "servicecidrs";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ServiceCidr {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ServiceCidr {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/node/v1/mod.rs
+++ b/k8s-pb/src/api/node/v1/mod.rs
@@ -92,12 +92,12 @@ impl crate::Resource for RuntimeClass {
     const URL_PATH_SEGMENT: &'static str = "runtimeclasses";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for RuntimeClass {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for RuntimeClass {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/policy/v1/mod.rs
+++ b/k8s-pb/src/api/policy/v1/mod.rs
@@ -169,12 +169,12 @@ impl crate::Resource for PodDisruptionBudget {
     const URL_PATH_SEGMENT: &'static str = "poddisruptionbudgets";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for PodDisruptionBudget {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for PodDisruptionBudget {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/rbac/v1/mod.rs
+++ b/k8s-pb/src/api/rbac/v1/mod.rs
@@ -204,12 +204,12 @@ impl crate::Resource for ClusterRole {
     const URL_PATH_SEGMENT: &'static str = "clusterroles";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ClusterRole {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ClusterRole {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -222,12 +222,12 @@ impl crate::Resource for ClusterRoleBinding {
     const URL_PATH_SEGMENT: &'static str = "clusterrolebindings";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ClusterRoleBinding {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ClusterRoleBinding {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -240,12 +240,12 @@ impl crate::Resource for Role {
     const URL_PATH_SEGMENT: &'static str = "roles";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for Role {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for Role {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -258,12 +258,12 @@ impl crate::Resource for RoleBinding {
     const URL_PATH_SEGMENT: &'static str = "rolebindings";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for RoleBinding {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for RoleBinding {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/resource/v1alpha3/mod.rs
+++ b/k8s-pb/src/api/resource/v1alpha3/mod.rs
@@ -927,12 +927,12 @@ impl crate::Resource for DeviceClass {
     const URL_PATH_SEGMENT: &'static str = "deviceclasses";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for DeviceClass {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for DeviceClass {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -954,12 +954,12 @@ impl crate::Resource for PodSchedulingContext {
     const URL_PATH_SEGMENT: &'static str = "podschedulingcontexts";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for PodSchedulingContext {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for PodSchedulingContext {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -990,12 +990,12 @@ impl crate::Resource for ResourceClaim {
     const URL_PATH_SEGMENT: &'static str = "resourceclaims";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for ResourceClaim {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ResourceClaim {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -1026,12 +1026,12 @@ impl crate::Resource for ResourceClaimTemplate {
     const URL_PATH_SEGMENT: &'static str = "resourceclaimtemplates";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for ResourceClaimTemplate {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ResourceClaimTemplate {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -1053,12 +1053,12 @@ impl crate::Resource for ResourceSlice {
     const URL_PATH_SEGMENT: &'static str = "resourceslices";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ResourceSlice {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ResourceSlice {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/scheduling/v1/mod.rs
+++ b/k8s-pb/src/api/scheduling/v1/mod.rs
@@ -53,12 +53,12 @@ impl crate::Resource for PriorityClass {
     const URL_PATH_SEGMENT: &'static str = "priorityclasses";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for PriorityClass {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for PriorityClass {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/storage/v1/mod.rs
+++ b/k8s-pb/src/api/storage/v1/mod.rs
@@ -574,12 +574,12 @@ impl crate::Resource for CsiDriver {
     const URL_PATH_SEGMENT: &'static str = "csidrivers";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for CsiDriver {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for CsiDriver {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -601,12 +601,12 @@ impl crate::Resource for CsiNode {
     const URL_PATH_SEGMENT: &'static str = "csinodes";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for CsiNode {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for CsiNode {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -628,12 +628,12 @@ impl crate::Resource for CsiStorageCapacity {
     const URL_PATH_SEGMENT: &'static str = "csistoragecapacities";
     type Scope = crate::NamespaceResourceScope;
 }
-impl crate::HasMetadata for CsiStorageCapacity {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for CsiStorageCapacity {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -646,12 +646,12 @@ impl crate::Resource for StorageClass {
     const URL_PATH_SEGMENT: &'static str = "storageclasses";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for StorageClass {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for StorageClass {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }
@@ -664,12 +664,12 @@ impl crate::Resource for VolumeAttachment {
     const URL_PATH_SEGMENT: &'static str = "volumeattachments";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for VolumeAttachment {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for VolumeAttachment {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/storage/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/storage/v1alpha1/mod.rs
@@ -259,12 +259,12 @@ impl crate::Resource for VolumeAttributesClass {
     const URL_PATH_SEGMENT: &'static str = "volumeattributesclasses";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for VolumeAttributesClass {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for VolumeAttributesClass {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/storage/v1beta1/mod.rs
+++ b/k8s-pb/src/api/storage/v1beta1/mod.rs
@@ -619,12 +619,12 @@ impl crate::Resource for VolumeAttributesClass {
     const URL_PATH_SEGMENT: &'static str = "volumeattributesclasses";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for VolumeAttributesClass {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for VolumeAttributesClass {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/api/storagemigration/v1alpha1/mod.rs
+++ b/k8s-pb/src/api/storagemigration/v1alpha1/mod.rs
@@ -111,12 +111,12 @@ impl crate::Resource for StorageVersionMigration {
     const URL_PATH_SEGMENT: &'static str = "storageversionmigrations";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for StorageVersionMigration {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for StorageVersionMigration {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/apiextensions_apiserver/pkg/apis/apiextensions/v1/mod.rs
+++ b/k8s-pb/src/apiextensions_apiserver/pkg/apis/apiextensions/v1/mod.rs
@@ -841,12 +841,12 @@ impl crate::Resource for CustomResourceDefinition {
     const URL_PATH_SEGMENT: &'static str = "customresourcedefinitions";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for CustomResourceDefinition {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for CustomResourceDefinition {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/kube_aggregator/pkg/apis/apiregistration/v1/mod.rs
+++ b/k8s-pb/src/kube_aggregator/pkg/apis/apiregistration/v1/mod.rs
@@ -140,12 +140,12 @@ impl crate::Resource for ApiService {
     const URL_PATH_SEGMENT: &'static str = "apiservices";
     type Scope = crate::ClusterResourceScope;
 }
-impl crate::HasMetadata for ApiService {
-    type Metadata = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-    fn metadata(&self) -> Option<&<Self as crate::HasMetadata>::Metadata> {
+impl crate::Metadata for ApiService {
+    type Ty = crate::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
-    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::HasMetadata>::Metadata> {
+    fn metadata_mut(&mut self) -> Option<&mut <Self as crate::Metadata>::Ty> {
         self.metadata.as_mut()
     }
 }

--- a/k8s-pb/src/lib.rs
+++ b/k8s-pb/src/lib.rs
@@ -45,10 +45,11 @@ pub trait Resource {
     #[doc = r" For example, `fn foo<T: k8s_openapi::Resource<Scope = k8s_openapi::ClusterResourceScope>>() { }` can only be called with cluster-scoped resources."]
     type Scope: ResourceScope;
 }
-pub trait HasMetadata {
-    type Metadata;
-    fn metadata(&self) -> Option<&Self::Metadata>;
-    fn metadata_mut(&mut self) -> Option<&mut Self::Metadata>;
+#[doc = r" A trait applied to all Kubernetes resources that have Metadata"]
+pub trait Metadata: Resource {
+    type Ty;
+    fn metadata(&self) -> Option<&Self::Ty>;
+    fn metadata_mut(&mut self) -> Option<&mut Self::Ty>;
 }
 pub trait HasSpec {
     type Spec;


### PR DESCRIPTION
trying to integrate a bit and this is an obvious thing to avoid

Now trait matches [k8s-openapi::Metadata](https://docs.rs/k8s-openapi/latest/k8s_openapi/trait.Metadata.html)