### PR TITLE
Fix irregular snake case conversions for fields

### DIFF
--- a/justfile
+++ b/justfile
@@ -87,6 +87,10 @@ names:
     rg 'IpAddress' k8s-pb -l | xargs sd 'IpAddress' 'IPAddress'
     rg 'ServiceCidr' k8s-pb -l | xargs sd 'ServiceCidr' 'ServiceCIDR'
     rg 'ClusterCidr' k8s-pb -l | xargs sd 'ClusterCidr' 'ClusterCIDR'
+    rg 'cluster_i_ps' k8s-pb -l | xargs sd 'cluster_i_ps' 'cluster_ips'
+    rg 'external_i_ps' k8s-pb -l | xargs sd 'external_i_ps' 'external_ips'
+    rg 'pod_i_ps' k8s-pb -l | xargs sd 'pod_i_ps' 'pod_ips'
+    rg 'host_i_ps' k8s-pb -l | xargs sd 'host_i_ps' 'host_ips'
     cargo fmt
 
 generate: swagger protos codegen names

--- a/k8s-pb/src/api/core/v1/mod.rs
+++ b/k8s-pb/src/api/core/v1/mod.rs
@@ -4636,7 +4636,7 @@ pub struct PodStatus {
     /// +patchMergeKey=ip
     /// +listType=atomic
     #[prost(message, repeated, tag = "16")]
-    pub host_i_ps: ::prost::alloc::vec::Vec<HostIp>,
+    pub host_ips: ::prost::alloc::vec::Vec<HostIp>,
     /// podIP address allocated to the pod. Routable at least within the cluster.
     /// Empty if not yet allocated.
     /// +optional
@@ -4651,7 +4651,7 @@ pub struct PodStatus {
     /// +listType=map
     /// +listMapKey=ip
     #[prost(message, repeated, tag = "12")]
-    pub pod_i_ps: ::prost::alloc::vec::Vec<PodIp>,
+    pub pod_ips: ::prost::alloc::vec::Vec<PodIp>,
     /// RFC 3339 date and time at which the object was acknowledged by the Kubelet.
     /// This is before the Kubelet pulled the container image(s) for the pod.
     /// +optional
@@ -6075,7 +6075,7 @@ pub struct ServiceSpec {
     /// +listType=atomic
     /// +optional
     #[prost(string, repeated, tag = "18")]
-    pub cluster_i_ps: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub cluster_ips: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// type determines how the Service is exposed. Defaults to ClusterIP. Valid
     /// options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
     /// "ClusterIP" allocates a cluster-internal IP address for load-balancing
@@ -6103,7 +6103,7 @@ pub struct ServiceSpec {
     /// +optional
     /// +listType=atomic
     #[prost(string, repeated, tag = "5")]
-    pub external_i_ps: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub external_ips: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Supports "ClientIP" and "None". Used to maintain session affinity.
     /// Enable client IP based session affinity.
     /// Must be ClientIP or None.


### PR DESCRIPTION
in a not amazing way, but it feels workable. Closes #2 (will open a new umbrella issue).

Not seeing any other cases like this from a quick search of the bad type names (CSI / CIDR / API), but there might be others. Not going to go chasing at the moment.